### PR TITLE
improve buidl system; added all and install targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,25 @@
 CPP_STANDARD := c++17
 CXXFLAGS := -O3 -fPIC -std=$(CPP_STANDARD)
+ifeq ($(strip $(PREFIX)),)
+PREFIX:=.
+endif
 
-.PHONY: clean
+.DEFAULT_GOAL := all
+.PHONY: clean all install
 
-emulator_interface.so: emulator.cc emulator.h
+EMULATOR_LIB:=libemulator_interface.so
+all: $(EMULATOR_LIB)
+	@echo All done
+
+install: all
+	@rm -rf $(PREFIX)/include $(PREFIX)/lib64
+	@mkdir -p $(PREFIX)/include $(PREFIX)/lib64
+	cp emulator.h $(PREFIX)/include/
+	cp -r ap_types $(PREFIX)/include/
+	cp $(EMULATOR_LIB) $(PREFIX)/lib64
+
+$(EMULATOR_LIB): emulator.cc emulator.h
 	$(CXX) $(CXXFLAGS) -shared $^ -o $@
 
 clean:
-	rm emulator_interface.so
+	rm $(EMULATOR_LIB)


### PR DESCRIPTION
Cleanup build system (Makefile)
- support standard `all` and `install` targets
- copy includes in PREFIX/include and libs in PREFIX/lib64