### PR TITLE
Check for nullptr in destructor to prevent segfault on failed model load

### DIFF
--- a/src/hls4ml/emulator.cc
+++ b/src/hls4ml/emulator.cc
@@ -9,6 +9,7 @@ ModelLoader::ModelLoader(std::string model_name)
 }
 
 ModelLoader::~ModelLoader(){
+  if (model_lib_ != nullptr)
     dlclose(model_lib_);
 }
 


### PR DESCRIPTION
Fixes https://github.com/cms-hls4ml/hls4mlEmulatorExtras/issues/3

Adds a check for a null pointer in the model loader destructor to prevent trying to close a `model_lib_` that may never have been opened, preventing segfaults.