### PR TITLE
Initialize model_lib_ to nullptr for defined destructor behavior

### DIFF
--- a/src/hls4ml/emulator.cc
+++ b/src/hls4ml/emulator.cc
@@ -4,6 +4,7 @@ using namespace hls4mlEmulator;
 
 ModelLoader::ModelLoader(std::string model_name)
 {
+    model_lib_ = nullptr; // Set to null for defined destructor behavior in case of failed load
     model_name_ = std::move(model_name);
     model_name_.append(".so");
 }


### PR DESCRIPTION
Response to https://github.com/cms-sw/cmsdist/pull/9064#issuecomment-1991687912, initializes `model_lib_` to `nullptr` to make sure the later destructor behavior is defined in case of failure to load a model.