### PR TITLE
add default ctor and `reset` method to `ModelLoader`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ $(EMULATOR_LIB): src/hls4ml/emulator.cc
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -shared $^ -o $@
 
 clean:
-	rm $(EMULATOR_LIB)
+	rm -f $(EMULATOR_LIB)

--- a/include/hls4ml/emulator.h
+++ b/include/hls4ml/emulator.h
@@ -26,7 +26,7 @@ namespace hls4mlEmulator
         void* model_lib_;
 
     public:
-        ModelLoader(std::string model_name);
+        ModelLoader(std::string const& model_name = "");
         ModelLoader(ModelLoader const&) = delete;
         ModelLoader& operator=(ModelLoader const&) = delete;
         //prevent move constructor/assignment
@@ -35,9 +35,12 @@ namespace hls4mlEmulator
         
         ~ModelLoader();
 
+        std::string const& model_name() const { return model_name_; }
+
+        void reset(std::string const& model_name = "");
+
         std::shared_ptr<Model> load_model();
     };
 }
 
 #endif
-


### PR DESCRIPTION
Small improvements to the `ModelLoader` class.

 - Add a default value for the model-name argument of its ctor.
 - Add a `reset` method to be used to (a) close the open shared library if needed, and (b) specify the name of a new shared library to be loaded.
 - Move the addition of `".so"` to the library name to the `load_model` method, so that the new method `model_name()` returns the model name specified in ctor or `reset`.
 - Minor update to the `Makefile` so that running `make clean` multiple times in a row does not lead to an error.

Backward compatible, and necessary for https://github.com/cms-sw/cmssw/pull/47070 (see https://github.com/cms-sw/cmssw/issues/46740).